### PR TITLE
addtion of sub page gambling restrictions

### DIFF
--- a/_careers/Internship Opportunities.md
+++ b/_careers/Internship Opportunities.md
@@ -17,8 +17,8 @@ experience, interns will be assigned to designated Public Defenders as
 supervising mentors.</p>
 <h4>Eligibility</h4>
 <p>We will consider applications from Singapore Citizens and Permanent Residents
-reading law either at local or scheduled overseas universities <em>[1]</em>.</p>
-<p>[1] <em>Overseas universities refer to institutions of higher learning outside Singapore and which are specified under the <a href="https://legisgov.agc.gov.sg/SL/LPA1966-R15?DocDate=20220112&amp;ProvIds=Sc4-XX-Sc4-#Sc4-XX-Sc4-" rel="noopener noreferrer nofollow" target="_blank">Schedules of the Legal Profession (Qualified Persons) Rules</a>.</em>
+reading law either at local or scheduled overseas universities <sup>1</sup>.</p>
+<p><sup>1 </sup><em>Overseas universities refer to institutions of higher learning outside Singapore and which are specified under the <a href="https://legisgov.agc.gov.sg/SL/LPA1966-R15?DocDate=20220112&amp;ProvIds=Sc4-XX-Sc4-#Sc4-XX-Sc4-" rel="noopener noreferrer nofollow" target="_blank">Schedules of the Legal Profession (Qualified Persons) Rules</a>.</em>
 </p>
 <p>Applicants are to take note of the following <strong>before</strong> applying:</p>
 <ul data-tight="true" class="tight">
@@ -30,5 +30,5 @@ reading law either at local or scheduled overseas universities <em>[1]</em>.</p>
 </li>
 </ul>
 <p>The next internship run will be from <strong>8 July 2024 to 26 July 2024</strong>.</p>
-<p>Application for the July 2024 internship (click <a href="https://go.gov.sg/pdointernship" rel="noopener noreferrer nofollow" target="_blank">here</a>) will be opens on 1 April
-2024 and closes on 30 April 2024. &nbsp;</p>
+<p>Application for the July 2024 internship (click <a href="https://go.gov.sg/pdointernship" rel="noopener noreferrer nofollow" target="_blank">here</a>) opens on 1 April 2024
+and closes on 30 April 2024. &nbsp;</p>

--- a/_criminal-defence-aid/Gambling activities restrictions.md
+++ b/_criminal-defence-aid/Gambling activities restrictions.md
@@ -1,0 +1,6 @@
+---
+title: Gambling activities restrictions
+permalink: /gambling-activities-restrictions/
+variant: tiptap
+description: ""
+---

--- a/_criminal-defence-aid/Gambling activities restrictions.md
+++ b/_criminal-defence-aid/Gambling activities restrictions.md
@@ -4,3 +4,27 @@ permalink: /gambling-activities-restrictions/
 variant: tiptap
 description: ""
 ---
+<p>Currently, individuals on Government social assistance and subsidy schemes
+are prohibited from entering the casinos, jackpot machine rooms and accessing
+their Singapore Pools online betting accounts under section 165A of the
+Casino Control Act 2006.</p>
+<p>With effect from 1 April 2024, this Exclusion by Law will be extended
+to individuals receiving Government-funded criminal defence aid from either
+the Public Defender’s Office or under the Criminal Legal Aid Scheme administered
+by Pro Bono SG.</p>
+<p>This means that for the period in which you are receiving criminal defence
+aid, you will be banned from:</p>
+<p>a. entering, remaining, or taking part in any gaming on all casino premises;</p>
+<p>b. entering, remaining, or taking part in any gaming in all jackpot machine
+rooms in private clubs (except for work<sup>1</sup> purposes); and</p>
+<p>c. accessing Singapore Pools accounts-related services if you are an existing
+account holder, or opening an account if you are not an existing account
+holder.</p>
+<p>When your case has concluded in Court or when you are no longer receiving
+criminal defence aid, this Exclusion by Law will be revoked automatically
+within 2 weeks.</p>
+<p>To understand more about social safeguards against problem gambling and
+exclusions or visit limits, please visit <a href="http://www.ncpg.org.sg" rel="noopener noreferrer nofollow" target="_blank">www.ncpg.org.sg</a>.</p>
+<p></p>
+<p><sup>1 </sup>This refers to the scope of “defined work” under Casino Control
+Act.</p>

--- a/_criminal-defence-aid/collection.yml
+++ b/_criminal-defence-aid/collection.yml
@@ -2,6 +2,7 @@ collections:
   criminal-defence-aid:
     output: true
     order:
+      - Gambling activities restrictions.md
       - Scope of Assistance.md
       - Qualifying for help.md
       - How to Apply.md

--- a/_criminal-defence-aid/collection.yml
+++ b/_criminal-defence-aid/collection.yml
@@ -2,9 +2,9 @@ collections:
   criminal-defence-aid:
     output: true
     order:
-      - Gambling activities restrictions.md
       - Scope of Assistance.md
       - Qualifying for help.md
       - How to Apply.md
+      - Gambling activities restrictions.md
       - After you apply.md
       - Common Questions.md

--- a/index.md
+++ b/index.md
@@ -5,7 +5,10 @@ description: The Public Defender’s Office is established to enhance access to
   justice to vulnerable persons through the provision of criminal defence aid.
 image: /images/PDO PMS HORZ-02.png
 permalink: /
-notification: ""
+notification: "Starting from 1 April 2024, all active recipients of criminal
+  defence aid will be prohibited from entering casinos, jackpot machine rooms
+  and accessing Singapore Pools online betting accounts. Click here for more
+  details. "
 sections:
   - hero:
       title: Public Defender's Office


### PR DESCRIPTION
Currently, individuals on Government social assistance and subsidy schemes are prohibited from entering the casinos, jackpot machine rooms and accessing their Singapore Pools online betting accounts under section 165A of the Casino Control Act 2006. With effect from 1 April 2024, this Exclusion by Law will be extended to individuals receiving Government-funded criminal defence aid from either the Public Defender’s Office or under the Criminal Legal Aid Scheme administered by Pro Bono SG.
This means that for the period in which you are receiving criminal defence aid, you will be banned from:

a.entering, remaining, or taking part in any gaming on all casino premises;
b.entering, remaining, or taking part in any gaming in all jackpot machine rooms in private clubs (except for work purposes); and
c.accessing Singapore Pools accounts-related services if you are an existing account holder, or opening an account if you are not an existing account holder. When your case has concluded in Court or when you are no longer receiving criminal defence aid, this Exclusion by Law will be revoked automatically within 2 weeks. To